### PR TITLE
Make addons a hash in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 services:
   - docker
 addons:
-  - postgresql: "9.4"
+  postgresql: "9.4"
 env:
   - ELASTIC_BEANSTALK_LABEL=$TRAVIS_TAG
 before_script:


### PR DESCRIPTION
It seems there's a bug in the normalization logic for .travis.yml contents that kicks in only if 
- there's an `addons` section which holds an array
- there's also a `deploy` section on the root level

I believe making `addons` a hash should fix this. If it does not, consider also moving the `deploy` section into the `addons` section.
